### PR TITLE
Add node@7 support to engines key

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "source-map-support": "^0.4.0"
   },
   "engines": {
-    "node": "6.x"
+    "node": "6.x||7.x"
   },
   "homepage": "https://github.com/glazedio/frisbee",
   "keywords": [


### PR DESCRIPTION
`yarn` throws a fit when it tries to install a package that claims not to support the current engine.

This might be better modeled as `>=6.x`, since the expectation is that it requires at least node v6, I think?